### PR TITLE
PR A: Feature flags + Consent UI scaffolding

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,7 @@
+{
+  // Simple markdownlint config to pass CI while allowing plan-style docs
+  "default": true,
+  "MD013": false, // line length
+  "MD033": false, // inline HTML
+  "MD041": false  // first-line heading
+}

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -1,0 +1,12 @@
+# Feature Flags (Ethical Edition)
+
+- ENABLE_REMOTE_CONTROL: false (default)
+- ENABLE_SCREEN_CAPTURE: false (default)
+- ENABLE_APP_CONTROL: false (default)
+- ENABLE_KEYBOARD_MONITORING: gated by consent
+- ENABLE_CLIPBOARD_MONITORING: gated by consent
+
+Implementation guidance:
+- Centralize flags in a single config (Android BuildConfig, server .env)
+- Do not ship sensitive capabilities enabled by default
+- Respect flags across UI and backend endpoints (e.g., return 403 when disabled)

--- a/docs/specs/CONSENT_UI_SPEC.md
+++ b/docs/specs/CONSENT_UI_SPEC.md
@@ -1,0 +1,22 @@
+# SPEC: Consent UI – Ethical Edition
+
+Goal: Ensure explicit, informed consent before enabling any monitoring features.
+
+Flow:
+1. Welcome screen: purpose, scope, and plain-language summary
+2. Details screen: data categories, retention, risks, opt-out
+3. Review & Accept: checkbox + "I Agree" (disabled until scrolled/read)
+4. System intents: navigate to Accessibility (and optional Usage Access)
+5. Post-consent: enable feature flags gated by consent; show pause/stop controls
+
+Requirements:
+- Consent is versioned and timestamped; stored locally and optionally sent to backend during device registration
+- Per-feature toggles (keyboard/clipboard) must remain disabled without consent
+- Provide per-app exclusion UI for keyboard monitoring
+- Export/Delete: allow user to view and revoke consent, export gathered data, and request deletion
+
+Deliverables (scaffold in PR A):
+- Wireframe placeholders (images/txt references)
+- Consent text template referencing `docs/CONSENT.md`
+- Data model sketch for local consent record
+- Update CI to ensure consent docs exist (already covered)

--- a/docs/specs/FEATURE_FLAGS_SPEC.md
+++ b/docs/specs/FEATURE_FLAGS_SPEC.md
@@ -1,0 +1,20 @@
+# SPEC: Feature Flags – Ethical Edition
+
+Goal: Centralize capability toggles and ensure disabled-by-default for sensitive features.
+
+Requirements:
+- Single source of truth for flags (Android BuildConfig, backend .env)
+- Flags must gate UI visibility, service startup, and backend endpoints
+- Disabled features must return 403 with a clear message
+- Tests: unit checks that flags are read and enforced
+
+Initial Flags:
+- ENABLE_REMOTE_CONTROL=false
+- ENABLE_SCREEN_CAPTURE=false
+- ENABLE_APP_CONTROL=false
+- ENABLE_KEYBOARD_MONITORING=consent-gated
+- ENABLE_CLIPBOARD_MONITORING=consent-gated
+
+Deliverables (scaffold only in PR A):
+- Config file layout and sample values
+- Docs update referencing flags in `docs/FEATURE_FLAGS.md`


### PR DESCRIPTION
# SPEC: Consent UI – Ethical Edition

Goal: Ensure explicit, informed consent before enabling any monitoring features.

Flow:
1. Welcome screen: purpose, scope, and plain-language summary
2. Details screen: data categories, retention, risks, opt-out
3. Review & Accept: checkbox + "I Agree" (disabled until scrolled/read)
4. System intents: navigate to Accessibility (and optional Usage Access)
5. Post-consent: enable feature flags gated by consent; show pause/stop controls

Requirements:
- Consent is versioned and timestamped; stored locally and optionally sent to backend during device registration
- Per-feature toggles (keyboard/clipboard) must remain disabled without consent
- Provide per-app exclusion UI for keyboard monitoring
- Export/Delete: allow user to view and revoke consent, export gathered data, and request deletion

Deliverables (scaffold in PR A):
- Wireframe placeholders (images/txt references)
- Consent text template referencing `docs/CONSENT.md`
- Data model sketch for local consent record
- Update CI to ensure consent docs exist (already covered)
