### PR TITLE
PR D: Retention, Audit Logs, and DSR policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           test -f docs/specs/FEATURE_FLAGS_SPEC.md
           test -f docs/specs/CONSENT_UI_SPEC.md
           test -f docs/specs/MONITORING_SPEC.md
+          test -f docs/RETENTION_POLICY.md
+          test -f docs/AUDIT_LOGS.md
+          test -f docs/DSR_POLICY.md
       - name: Markdown lint (remark)
         uses: avto-dev/markdown-lint@v1
         with:

--- a/docs/AUDIT_LOGS.md
+++ b/docs/AUDIT_LOGS.md
@@ -1,0 +1,20 @@
+# Audit Logging Policy (Ethical Research Edition)
+
+Objectives:
+- Track access to collected data and administrative actions
+- Provide traceability for investigations and compliance
+
+What to log (avoid sensitive contents):
+- Actor (user/admin id), device_id, action, target (resource), timestamp, outcome, request_id
+- Examples: data export initiated/completed, data deletion, consent changes, API ingestion counts
+
+Controls:
+- Logs immutable (append-only); rotation and secure storage
+- Access restricted; access to logs is itself audited
+- Time sync (NTP) to ensure reliable timestamps
+
+Retention:
+- Default 90 days (configurable); align with privacy policy and legal requirements
+
+Monitoring:
+- Alerts on suspicious patterns (excessive exports, failed deletions, repeated unauthorized access)

--- a/docs/DSR_POLICY.md
+++ b/docs/DSR_POLICY.md
@@ -1,0 +1,17 @@
+# Data Subject Requests (DSR) Policy (Ethical Research Edition)
+
+Supported requests (where applicable):
+- Access: provide subject with a summary and export of their data
+- Deletion: delete subject data across primary storage and backups (when feasible)
+- Rectification: update metadata upon verified request
+- Consent revocation: stop processing and delete data collected under that consent
+
+Process:
+- Verify identity (multi-factor where possible)
+- Record request with ticket ID and timestamp
+- Fulfill within defined SLA (e.g., 30 days) and notify subject
+
+Implementation guidance:
+- Provide API endpoints/hooks for export/delete
+- Ensure audit logs capture requests and outcomes
+- Coordinate with retention jobs to prevent re-ingestion after deletion

--- a/docs/RETENTION_POLICY.md
+++ b/docs/RETENTION_POLICY.md
@@ -1,0 +1,17 @@
+# Data Retention Policy (Ethical Research Edition)
+
+Principles:
+- Data minimization and short retention windows
+- Clear, documented retention periods by data type
+- Automatic deletion after retention period
+- Immediate deletion on consent revocation or DSR request
+
+Defaults (can be tightened per study):
+- Keystroke metadata: 14 days
+- Clipboard entries: 7 days
+- Aggregated telemetry/metrics: 30 days
+
+Implementation guidance:
+- Store `created_at`/`expires_at` on records; scheduled job to purge expired
+- Ensure backups follow the same retention windows
+- Document exceptions (legal hold) and approval workflow


### PR DESCRIPTION
# Data Retention Policy (Ethical Research Edition)

Principles:
- Data minimization and short retention windows
- Clear, documented retention periods by data type
- Automatic deletion after retention period
- Immediate deletion on consent revocation or DSR request

Defaults (can be tightened per study):
- Keystroke metadata: 14 days
- Clipboard entries: 7 days
- Aggregated telemetry/metrics: 30 days

Implementation guidance:
- Store `created_at`/`expires_at` on records; scheduled job to purge expired
- Ensure backups follow the same retention windows
- Document exceptions (legal hold) and approval workflow
